### PR TITLE
Fix char signedness compilation error

### DIFF
--- a/stm32-nucleo-l4r5zi/include/hal/lib.h
+++ b/stm32-nucleo-l4r5zi/include/hal/lib.h
@@ -9,6 +9,6 @@ void default_hndlr(void);
 
 void hal_hw_init(void);
 
-void hal_semih_write_debug(const int8_t *msg);
+void hal_semih_write_debug(const char *msg);
 
 #endif /* HAL_H */

--- a/stm32-nucleo-l4r5zi/src/lib.rs
+++ b/stm32-nucleo-l4r5zi/src/lib.rs
@@ -8,6 +8,7 @@ pub extern crate cortex_m as common;
 
 use common::*;
 use core::ops::Add;
+use core::ffi::c_char;
 
 const RCC_BASE: u32 = 0x40021000;
 const RCC_AHB2ENR_OFFSET: u32 = 0x4C;
@@ -47,6 +48,6 @@ fn init_systick() {
  * Postconditions: none
  */
 #[no_mangle]
-pub extern "C" fn hal_semih_write_debug(msg: *const i8) {
+pub extern "C" fn hal_semih_write_debug(msg: *const c_char) {
     cortex_m::semih::hio::write_debug(unsafe { core::ffi::CStr::from_ptr(msg) });
 }


### PR DESCRIPTION
Explicit casting removes the compilation error arising from arch-specific char-signedness. 
On ARM systems, chars are usually unsigned, so the type should be *const u8 (or, more generally, just using the c_char of the official signature)